### PR TITLE
correct failing version of cffi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ bitstring==3.1.9
 cachetools==5.2.0
 capstone==5.0.3
 cart==1.2.3
-cffi==1.15.1
+cffi==1.17
 claripy==9.2.141
 cle==9.2.141
 click==8.1.3


### PR DESCRIPTION
When installing the requirements (using a venv and CPython 3.13.15 on Debian) I ran into a failure to build cffi.
To correct it I just needed to switch from version 1.15 to 1.17.